### PR TITLE
Add DELETE endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 
 # Build the binary.
 # CGO_ENABLED=0 creates a static binary (no external C library dependencies)
-RUN CGO_ENABLED=0 GOOS=linux go build -o kv-server cmd/server/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o kv-server ./cmd/server
 
 # --- Stage 2: Runner ---
 # Use a tiny Alpine Linux image

--- a/cmd/server/handlers.go
+++ b/cmd/server/handlers.go
@@ -47,3 +47,35 @@ func handlePut(store *kv.Store, nodeID int, peerTemplate string) http.HandlerFun
 		w.Write([]byte("Success"))
 	}
 }
+
+func handleDelete(store *kv.Store, nodeID int, peerTemplate string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.Query().Get("key")
+
+		if key == "" {
+			http.Error(w, "key is required", http.StatusBadRequest)
+			return
+		}
+		err := store.Put(key, "", true)
+		if err != nil {
+			if err.Error() == "not leader" {
+				leaderID := store.Raft.GetLeader()
+				if leaderID == -1 {
+					http.Error(w, "Leader not found", http.StatusNotFound)
+					return
+				}
+				if leaderID == nodeID {
+					http.Error(w, "Cluster in leadership transition", http.StatusServiceUnavailable)
+					return
+				}
+				leaderURL := fmt.Sprintf(peerTemplate, leaderID)
+				targetURL := fmt.Sprintf("%s/delete?key=%s", leaderURL, key)
+				forwardToLeader(w, r, targetURL)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -51,6 +51,7 @@ func main() {
 	// Register HTTP handlers
 	http.HandleFunc("/get", withMetrics(handleGet(store), "GET", "/get"))
 	http.HandleFunc("/put", withMetrics(handlePut(store, *id, *peerTemplate), "PUT", "/put"))
+	http.HandleFunc("/delete", withMetrics(handleDelete(store, *id, *peerTemplate), "DELETE", "/delete"))
 	http.Handle("/metrics", promhttp.Handler())
 
 	fmt.Printf("HTTP server listening on :%s\n", *httpPort)


### PR DESCRIPTION
Added DELETE endpoint with input validation.
Updated Dockerfile build scope to include ./cmd/server, fixing docker-compose build errors caused by missing handlers during multi-file builds.
Tested PUT, GET, and DELETE endpoints locally using curl.

Fixes #3