### PR TITLE
feat: add --log-requests flag to make HTTP logging configurable

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,6 +71,11 @@ go run ./cmd/server/ \
   -peer-template "http://localhost:800%d"
 ```
 
+> **Note:** By default, HTTP request logging is disabled for better performance. To enable request logging (useful for debugging), add the `-log-requests` flag:
+> ```
+> go run ./cmd/server/ -id 0 -port 5001 -http 8000 -peers :5001,:5002,:5003 -peer-template "http://localhost:800%d" -log-requests
+> ```
+
 ### 3. Verify Connectivity
 
 Test a write to the Leader (usually Node 0 or 1):

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -23,6 +23,7 @@ func main() {
 	rpcPort := flag.String("port", "5001", "gRPC port")
 	httpPort := flag.String("http", "8001", "HTTP port")
 	peerTemplate := flag.String("peer-template", "http://kv-%d:8001", "Peer URL template")
+	logRequests := flag.Bool("log-requests", false, "Enable HTTP request logging")
 	flag.Parse()
 
 	// Initialize Raft clients
@@ -49,9 +50,9 @@ func main() {
 	go startGRPCServer(*rpcPort, store)
 
 	// Register HTTP handlers
-	http.HandleFunc("/get", httpLogger(withMetrics(handleGet(store), "GET", "/get")))
-	http.HandleFunc("/put", httpLogger(withMetrics(handlePut(store, *id, *peerTemplate), "PUT", "/put")))
-	http.HandleFunc("/delete", httpLogger(withMetrics(handleDelete(store, *id, *peerTemplate), "DELETE", "/delete")))
+	http.HandleFunc("/get", httpLogger(withMetrics(handleGet(store), "GET", "/get"), *logRequests))
+	http.HandleFunc("/put", httpLogger(withMetrics(handlePut(store, *id, *peerTemplate), "PUT", "/put"), *logRequests))
+	http.HandleFunc("/delete", httpLogger(withMetrics(handleDelete(store, *id, *peerTemplate), "DELETE", "/delete"), *logRequests))
 	http.Handle("/metrics", promhttp.Handler())
 
 	fmt.Printf("HTTP server listening on :%s\n", *httpPort)

--- a/cmd/server/middleware.go
+++ b/cmd/server/middleware.go
@@ -20,7 +20,11 @@ func (ww *responseWriterWrapper) WriteHeader(code int) {
 }
 
 // httpLogger logs HTTP requests in the format: [HTTP] METHOD PATH STATUS_CODE STATUS_TEXT DURATION_MS
-func httpLogger(handler http.HandlerFunc) http.HandlerFunc {
+// When enableLogging is false, the handler is called directly without logging overhead
+func httpLogger(handler http.HandlerFunc, enableLogging bool) http.HandlerFunc {
+	if !enableLogging {
+		return handler
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		ww := &responseWriterWrapper{ResponseWriter: w, statusCode: 200}


### PR DESCRIPTION
  Fixes #22

   ## Problem
   The `httpLogger` middleware in `cmd/server/middleware.go` was unconditionally applied to every HTTP handler (`/get`, `/put`, `/delete`), adding a `log.Printf` call on every single request.
   Under high write RPS, this introduced unnecessary overhead from string formatting and I/O on the hot path.

   ## Solution
   - Added `--log-requests` CLI flag (default: `false`)
   - Modified `httpLogger` middleware to accept an `enableLogging bool` parameter
   - When disabled, the handler is returned directly without any wrapper, eliminating all overhead

   ## Usage
  Default: no request logging (better performance)
  ./server -id 0 -peers "..."

  Enable request logging when needed for debugging
  ./server -id 0 -peers "..." -log-requests

   ## Files Changed
   - `cmd/server/main.go` - Added `--log-requests` flag
   - `cmd/server/middleware.go` - Made `httpLogger` configurable